### PR TITLE
Validate pid before calling

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@ var cp = require("child_process");
 var camelCase = require("camelcase");
 
 function getProcessLimits(pid, callback) {
+    if (!Number.isInteger(pid)) {
+        callback(new Error("pid must be an integer"));
+        return;
+    }
+
     cp.exec("cat /proc/" + pid + "/limits", function (err, stdout, stderr) {
         if (err) return callback(err);
         

--- a/test.js
+++ b/test.js
@@ -45,6 +45,17 @@ test("getProcessLimits", function (t) {
     });
 })
 
+test("getProcessLimits validation", function (t) {
+    processLimits("..", function (err, limits) {
+        assert(err instanceof Error);
+        assert.strictEqual(err.message, "pid must be an integer");
+
+        assert.strictEqual(limits, undefined);
+
+        t.end();
+    });
+});
+
 test("parseProcessLimits", function (t) {
      var sampleData = "" +
         "Limit                     Soft Limit           Hard Limit           Units     \n" +


### PR DESCRIPTION
`getProcessLimits` calls `child_process.exec` with the pid. Here's the relevant line:

```js
cp.exec("cat /proc/" + pid + "/limits", function (err, stdout, stderr) {
```

A malicious argument could cause trouble. For example, passing an argument of `'; rm -rf / #'` would run the following command:

    cat /proc/; rm -rf / #/limits

This minimal change validates the pid argument before continuing.